### PR TITLE
moved ReviewOutputDto and ReviewResponseDto to Application proj

### DIFF
--- a/src/ReviewAutomation/Api/Controllers/ReviewsController.cs
+++ b/src/ReviewAutomation/Api/Controllers/ReviewsController.cs
@@ -1,5 +1,5 @@
 using Athos.ReviewAutomation.Core.Interfaces;
-using Athos.ReviewAutomation.Core.DTOs;
+using Athos.ReviewAutomation.Application.DTOs.Reviews;
 using Microsoft.AspNetCore.Mvc;
 using Athos.ReviewAutomation.Application.UseCases.Reviews;
 

--- a/src/ReviewAutomation/Application/DTOs/Reviews/ReviewOutputDto.cs
+++ b/src/ReviewAutomation/Application/DTOs/Reviews/ReviewOutputDto.cs
@@ -1,4 +1,4 @@
-namespace Athos.ReviewAutomation.Core.DTOs
+namespace Athos.ReviewAutomation.Application.DTOs.Reviews
 {
     public class ReviewOutputDto
     {

--- a/src/ReviewAutomation/Application/DTOs/Reviews/ReviewResponseDto.cs
+++ b/src/ReviewAutomation/Application/DTOs/Reviews/ReviewResponseDto.cs
@@ -1,4 +1,4 @@
-namespace Athos.ReviewAutomation.Core.DTOs
+namespace Athos.ReviewAutomation.Application.DTOs.Reviews
 {
     public class ReviewResponseDto
     {

--- a/src/ReviewAutomation/Application/UseCases/Reviews/ApproveReviewUseCase.cs
+++ b/src/ReviewAutomation/Application/UseCases/Reviews/ApproveReviewUseCase.cs
@@ -1,6 +1,4 @@
-using Athos.ReviewAutomation.Core.DTOs;
-using Athos.ReviewAutomation.Infrastructure.Services;
-using Athos.ReviewAutomation.Models;
+using Athos.ReviewAutomation.Application.DTOs.Reviews;
 
 namespace Athos.ReviewAutomation.Application.UseCases.Reviews
 {

--- a/src/ReviewAutomation/Application/UseCases/Reviews/IApproveReviewUseCase.cs
+++ b/src/ReviewAutomation/Application/UseCases/Reviews/IApproveReviewUseCase.cs
@@ -1,5 +1,4 @@
-using Athos.ReviewAutomation.Core.DTOs;
-using Athos.ReviewAutomation.Models;
+using Athos.ReviewAutomation.Application.DTOs.Reviews;
 
 namespace Athos.ReviewAutomation.Application.UseCases.Reviews
 {


### PR DESCRIPTION
Moved ReviewOutputDto and ReviewResponseDto from Core to Application/DTOs/Reviews

Aligns with Clean Architecture by treating DTOs as use case-level concerns

Keeps Core focused on domain entities (DbReview) and business logic

Prepares for better encapsulation and maintainability of request/response models