### PR TITLE
mock mode toggle

### DIFF
--- a/src/Dashboard/package-lock.json
+++ b/src/Dashboard/package-lock.json
@@ -8,8 +8,10 @@
       "name": "dashboard",
       "version": "0.0.0",
       "dependencies": {
+        "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-slot": "^1.2.2",
+        "@radix-ui/react-switch": "^1.2.5",
         "@tailwindcss/vite": "^4.1.7",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1331,6 +1333,29 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-popper": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.7.tgz",
@@ -1467,6 +1492,35 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.5.tgz",
+      "integrity": "sha512-5ijLkak6ZMylXsaImpZ8u4Rlf5grRmoc0p0QeX9VJtlrM4f5m3nCTX8tWga/zOA8PZYIR/t0p2Mnvd7InrJ6yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/src/Dashboard/package.json
+++ b/src/Dashboard/package.json
@@ -10,8 +10,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slot": "^1.2.2",
+    "@radix-ui/react-switch": "^1.2.5",
     "@tailwindcss/vite": "^4.1.7",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/Dashboard/src/App.tsx
+++ b/src/Dashboard/src/App.tsx
@@ -1,13 +1,20 @@
 import { Layout } from "./components/layout/Layout";
 import { ReviewList } from "./components/reviews/ReviewList";
+import { MockApiProvider } from "./context/MockApiContext";
+import { MockModeToggle } from "./components/MockModeToggle";
 
 function App() {
     return (
-        <div className="min-h-screen bg-background text-foreground">
-            <Layout>
-                <ReviewList />
-            </Layout>
-        </div>
+        <MockApiProvider>
+            <div className="min-h-screen bg-background text-foreground">
+                <div className="p-4">
+                    <MockModeToggle />
+                </div>
+                <Layout>
+                    <ReviewList />
+                </Layout>
+            </div>
+        </MockApiProvider>
     );
 }
 

--- a/src/Dashboard/src/components/MockModeToggle.tsx
+++ b/src/Dashboard/src/components/MockModeToggle.tsx
@@ -1,0 +1,18 @@
+import { Switch } from "@/components/ui/switch"
+import { Label } from "@/components/ui/label"
+import { useMockApiContext } from "@/context/MockApiContext"
+
+export function MockModeToggle() {
+    const { useMockApi, toggleMockApi } = useMockApiContext()
+
+    return (
+        <div className="flex items-center space-x-3 p-2">
+            <Switch
+                id="mock-mode-switch"
+                checked={useMockApi}
+                onCheckedChange={toggleMockApi}
+            />
+            <Label htmlFor="mock-mode-switch">Mock Mode</Label>
+        </div>
+    )
+}

--- a/src/Dashboard/src/components/reviews/ReviewList.tsx
+++ b/src/Dashboard/src/components/reviews/ReviewList.tsx
@@ -12,7 +12,7 @@ import {
     SelectValue
 } from "@/components/ui/select"
 import { Loader2 } from "lucide-react"
-
+import { useMockApiContext } from "@/context/MockApiContext"
 type Review = {
     reviewId: string
     author: string
@@ -23,6 +23,7 @@ type Review = {
 }
 
 export function ReviewList() {
+    const { useMockApi } = useMockApiContext()
     const [reviews, setReviews] = useState<Review[]>([])
     const [loading, setLoading] = useState(true)
     const [submittingId, setSubmittingId] = useState<string | null>(null)
@@ -33,11 +34,15 @@ export function ReviewList() {
     const [sentimentFilter, setSentimentFilter] = useState("all")
     const [statusFilter, setStatusFilter] = useState("all")
 
-    // 🔁 Fetch reviews from API
+    const baseUrl = useMockApi
+        ? "https://localhost:7157/api/mock"
+        : "https://localhost:7157/api"
+
+    // 🔁 Fetch reviews
     const fetchReviews = async () => {
         setLoading(true)
         try {
-            const res = await fetch("https://localhost:7157/api/reviews")
+            const res = await fetch(`${baseUrl}/reviews`)
             const json = await res.json()
             setReviews(json.data ?? [])
         } catch (err) {
@@ -49,14 +54,14 @@ export function ReviewList() {
 
     useEffect(() => {
         fetchReviews()
-    }, [])
+    }, [useMockApi])
 
     // ✅ Submit response
     const handleApprove = async (reviewId: string, finalResponse: string) => {
         setSubmittingId(reviewId)
 
         try {
-            const res = await fetch("https://localhost:7157/api/reviews/respond", {
+            const res = await fetch(`${baseUrl}/respond`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ reviewId, finalResponse })
@@ -79,7 +84,7 @@ export function ReviewList() {
         }
     }
 
-    // 🧠 Apply filters and search
+    // 🧠 Filtered reviews
     const filteredReviews = reviews.filter(r => {
         const matchesSearch =
             r.comment.toLowerCase().includes(searchQuery.toLowerCase()) ||
@@ -98,7 +103,7 @@ export function ReviewList() {
 
     return (
         <div className="grid gap-4 px-4">
-            {/* 🔎 Search + Filter Controls */}
+            {/* 🔎 Search + Filters */}
             <div className="flex flex-wrap gap-2 items-center justify-between">
                 <Input
                     placeholder="Search reviews..."
@@ -119,10 +124,7 @@ export function ReviewList() {
                     </SelectContent>
                 </Select>
 
-                <Select
-                    value={statusFilter}
-                    onValueChange={setStatusFilter}
-                >
+                <Select value={statusFilter} onValueChange={setStatusFilter}>
                     <SelectTrigger className="w-[160px]">
                         <SelectValue placeholder="All Statuses" />
                     </SelectTrigger>
@@ -133,7 +135,6 @@ export function ReviewList() {
                     </SelectContent>
                 </Select>
 
-                {/* 🔁 Refresh Button */}
                 <Button variant="outline" onClick={fetchReviews} disabled={loading}>
                     {loading ? (
                         <>

--- a/src/Dashboard/src/components/ui/label.tsx
+++ b/src/Dashboard/src/components/ui/label.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/src/Dashboard/src/components/ui/switch.tsx
+++ b/src/Dashboard/src/components/ui/switch.tsx
@@ -1,0 +1,27 @@
+import * as React from "react"
+import * as SwitchPrimitives from "@radix-ui/react-switch"
+
+import { cn } from "@/lib/utils"
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+      )}
+    />
+  </SwitchPrimitives.Root>
+))
+Switch.displayName = SwitchPrimitives.Root.displayName
+
+export { Switch }

--- a/src/Dashboard/src/context/MockApiContext.tsx
+++ b/src/Dashboard/src/context/MockApiContext.tsx
@@ -1,0 +1,34 @@
+import { createContext, useContext, useEffect, useState } from "react"
+
+type MockApiContextType = {
+    useMockApi: boolean
+    toggleMockApi: () => void
+}
+
+const MockApiContext = createContext<MockApiContextType | undefined>(undefined)
+
+export function MockApiProvider({ children }: { children: React.ReactNode }) {
+    const [useMockApi, setUseMockApi] = useState(() => {
+        return localStorage.getItem("useMockApi") === "true"
+    })
+
+    useEffect(() => {
+        localStorage.setItem("useMockApi", String(useMockApi))
+    }, [useMockApi])
+
+    const toggleMockApi = () => setUseMockApi(prev => !prev)
+
+    return (
+        <MockApiContext.Provider value={{ useMockApi, toggleMockApi }}>
+            {children}
+        </MockApiContext.Provider>
+    )
+}
+
+export function useMockApiContext() {
+    const context = useContext(MockApiContext)
+    if (!context) {
+        throw new Error("useMockApiContext must be used within a MockApiProvider")
+    }
+    return context
+}

--- a/src/ReviewAutomation/Api/Controllers/MockReviewApiController.cs
+++ b/src/ReviewAutomation/Api/Controllers/MockReviewApiController.cs
@@ -1,0 +1,6 @@
+namespace Athos.ReviewAutomation.Api.Controllers;
+
+public class MockReviewApiController
+{
+    
+}


### PR DESCRIPTION
Added context-based mock mode.
Any component can toggle or read mock mode without prop drilling.
API logic and UI are cleanly decoupled from configuration.

	1.	Onboarding & Confidence Building
Let business owners experiment with replying to reviews, customizing responses, etc., without fear of messing something up.
	2.	Demo-Friendly
Great for you to showcase the platform in action with “fake” data.
	3.	Sales Enablement
You can preload mock reviews and show off key features like customization, sentiment detection, and dark mode—without needing a live integration.
	4.	Reduced Risk
No accidental “real” responses or data corruption from curious testers.